### PR TITLE
Bug fix for icc: always compile tools with gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,9 @@ tools:
 	@echo "Go not installed; skipping tools' compilation"
 else
 tools:
-	cd tools && make;
+	# We overwite CC because we discovered issues when CC=icc and in our context,
+	# the tools can always be compiled with gcc.
+	cd tools && make CC=gcc;
 endif
 
 check: libraries


### PR DESCRIPTION
Signed-off-by: Geoffroy Vallee <geoffroy.vallee@gmail.com>