### PR TITLE
Validation steps to run emptying bug

### DIFF
--- a/examples/alltoall_demo.c
+++ b/examples/alltoall_demo.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[]) {
     printf("MPI Datatypes used:\n");
     int i;
     for (i=0; i<4; i++){
-        printf("name, value: %s, %i\n", type_strings[i], (uint64_t) MPI_Datatypes_used[i]);
+        printf("name, value: %s, %li\n", type_strings[i], (uint64_t) MPI_Datatypes_used[i]);
     }
 
 

--- a/examples/alltoall_test_helpers.h
+++ b/examples/alltoall_test_helpers.h
@@ -189,7 +189,7 @@ void print_buffers(int my_rank, int world_size, alltoall_test_node_params_t* par
                             printf(" %08x ", ((uint32_t*)sendbuf)[block_idx * param_set->sendcount + idx]);
                             break;
                         case 3:
-                            printf(" %016x ", ((uint64_t*)sendbuf)[block_idx * param_set->sendcount + idx]);
+                            printf(" %016lx ", ((uint64_t*)sendbuf)[block_idx * param_set->sendcount + idx]);
                             break;
                     }
                 }
@@ -210,7 +210,7 @@ void print_buffers(int my_rank, int world_size, alltoall_test_node_params_t* par
                             printf(" %08x ", ((uint32_t*)recvbuf)[block_idx * param_set->recvcount + idx]);
                             break;
                         case 3:
-                            printf(" %016x ", ((uint64_t*)recvbuf)[block_idx * param_set->recvcount + idx]);
+                            printf(" %016lx ", ((uint64_t*)recvbuf)[block_idx * param_set->recvcount + idx]);
                             break;
                     }
                 }

--- a/tools/cmd/validate/validate.go
+++ b/tools/cmd/validate/validate.go
@@ -107,39 +107,40 @@ type Test struct {
 
 type testCfg struct {
 	tempDir string
-	cfg     Test
+	cfg     *Test
 }
 
-func printValidationStepsToRun(validationStepsToRun *map[int]bool, heading string) {
-	fmt.Printf("validationStepsToRun value (%s): %v \n", heading, validationStepsToRun)
+type validationCfg struct {
+	sharedLibraries []string
+	tests           []Test
+	testCfgs        map[string]*testCfg
 }
 
-func updateValidationStepsDependencies(tt *Test) {
-	tt.validationStepsToRun = make(map[int]bool)
-	printValidationStepsToRun(&tt.validationStepsToRun, "on map init in updateValidationStepsDependencies")
+func (v *validationCfg) updateValidationStepsDependencies() {
+	for _, tt := range v.tests {
+		v.testCfgs[tt.binary].cfg.validationStepsToRun = make(map[int]bool)
 
-	for _, step := range tt.requestedValidationStepsToRun {
-		if step == allValidationSteps {
-			for i := 0; i < webuiStep; i++ {
-				tt.validationStepsToRun[i] = true
+		for _, step := range v.testCfgs[tt.binary].cfg.requestedValidationStepsToRun {
+			if step == allValidationSteps {
+				for i := 0; i <= webuiStep; i++ {
+					v.testCfgs[tt.binary].cfg.validationStepsToRun[i] = true
+				}
 			}
-		}
 
-		if step == webuiStep {
-			tt.validationStepsToRun[postmortemProfilerStep] = true
-		}
+			if step == webuiStep {
+				v.testCfgs[tt.binary].cfg.validationStepsToRun[postmortemProfilerStep] = true
+			}
 
-		if step == postmortemProfilerStep || step == postmortemSRCountAnalyzerStep {
-			tt.validationStepsToRun[traceGenerationStep] = true
-		}
+			if step == postmortemProfilerStep || step == postmortemSRCountAnalyzerStep {
+				v.testCfgs[tt.binary].cfg.validationStepsToRun[traceGenerationStep] = true
+			}
 
-		tt.validationStepsToRun[step] = true
+			v.testCfgs[tt.binary].cfg.validationStepsToRun[step] = true
+		}
 	}
-	printValidationStepsToRun(&tt.validationStepsToRun, "after setting in updateValidationStepsDependencies")
 }
 
 func validationStepIsSet(tt *Test, requestedStep int) bool {
-	printValidationStepsToRun(&tt.validationStepsToRun, "in validationStepIsSet")
 	return tt.validationStepsToRun[requestedStep]
 }
 
@@ -172,7 +173,7 @@ func checkOutputFiles(expectedOutputDir string, tempDir string, expectedFiles []
 		}
 		if hashRefFile != hashResultFile {
 			fmt.Println(" failed")
-			return fmt.Errorf("Invalid output, send counters do not match (%s vs. %s)", resultFile, referenceFile)
+			return fmt.Errorf("invalid output, send counters do not match (%s vs. %s)", resultFile, referenceFile)
 		}
 		fmt.Println(" ok")
 	}
@@ -180,7 +181,7 @@ func checkOutputFiles(expectedOutputDir string, tempDir string, expectedFiles []
 	return nil
 }
 
-func checkFormatTimingFile(filepath string, codeBaseDir string, expectedNumCalls int, expectedNumRanks int, tt Test) error {
+func checkFormatTimingFile(filepath string, codeBaseDir string, expectedNumCalls int, expectedNumRanks int, tt *Test) error {
 	md, _, _, err := timings.ParseTimingFile(filepath, codeBaseDir)
 	if err != nil {
 		return fmt.Errorf("timings.ParseTimingFile(() failed: %s", err)
@@ -194,7 +195,7 @@ func checkFormatTimingFile(filepath string, codeBaseDir string, expectedNumCalls
 	return nil
 }
 
-func checkOutput(codeBaseDir string, tempDir string, tt Test) error {
+func checkOutput(codeBaseDir string, tempDir string, tt *Test) error {
 	expectedOutputDir := filepath.Join(codeBaseDir, "tests", tt.binary, "expectedOutput")
 
 	fmt.Printf("Checking if %s exist(s)...\n", tt.expectedSendCompactCountsFiles)
@@ -367,14 +368,14 @@ func validateDatasetProfiler(codeBaseDir string, collectiveName string, testCfg 
 }
 
 func validateTestPostmortemResults(codeBaseDir string, collectiveName string, testCfg *testCfg) error {
-	if validationStepIsSet(&testCfg.cfg, postmortemSRCountAnalyzerStep) {
+	if validationStepIsSet(testCfg.cfg, postmortemSRCountAnalyzerStep) {
 		err := validateTestSRCountsAnalyzer(testCfg.cfg.binary, testCfg.tempDir)
 		if err != nil {
 			return err
 		}
 	}
 
-	if validationStepIsSet(&testCfg.cfg, postmortemProfilerStep) {
+	if validationStepIsSet(testCfg.cfg, postmortemProfilerStep) {
 		err := validateDatasetProfiler(codeBaseDir, collectiveName, testCfg)
 		if err != nil {
 			return err
@@ -384,9 +385,9 @@ func validateTestPostmortemResults(codeBaseDir string, collectiveName string, te
 	return nil
 }
 
-func validatePostmortemAnalysisTools(codeBaseDir string, collectiveName string, profilerResults map[string]*testCfg) error {
-	for source, testCfg := range profilerResults {
-		if validationStepIsSet(&testCfg.cfg, postmortemSRCountAnalyzerStep) || validationStepIsSet(&testCfg.cfg, postmortemProfilerStep) {
+func (v *validationCfg) postmortemAnalysisTools(codeBaseDir string, collectiveName string) error {
+	for source, testCfg := range v.testCfgs {
+		if validationStepIsSet(testCfg.cfg, postmortemSRCountAnalyzerStep) || validationStepIsSet(testCfg.cfg, postmortemProfilerStep) {
 			err := validateTestPostmortemResults(codeBaseDir, collectiveName, testCfg)
 			if err != nil {
 				fmt.Printf("validation of the postmortem analysis for %s in %s failed: %s\n", source, testCfg.tempDir, err)
@@ -458,6 +459,9 @@ func validateIndexPage(codeBaseDir string, cfg *webui.Config) error {
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
 	bs := string(body)
 	return checkIndexPageContent(codeBaseDir, bs)
 }
@@ -486,6 +490,9 @@ func validateCallPage(codeBaseDir string, cfg *webui.Config, testCfg *testCfg) e
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
 	bs := string(body)
 
 	return checkCallPageContent(codeBaseDir, testCfg, bs)
@@ -501,6 +508,9 @@ func validatePatternsPage(codeBaseDir string, cfg *webui.Config, testCfg *testCf
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
 	bs := string(body)
 
 	return checkPatternsPageContent(codeBaseDir, testCfg, bs)
@@ -564,12 +574,12 @@ func validateWebUIForTest(codeBaseDir string, testCfg *testCfg, port int) error 
 	return nil
 }
 
-func validateWebUI(codeBaseDir string, collectiveName string, profilerResults map[string]*testCfg) error {
+func (v *validationCfg) webUI(codeBaseDir string, collectiveName string) error {
 	fmt.Println("- Validating the webUI")
 	port := webui.DefaultPort
 
-	for _, testCfg := range profilerResults {
-		if validationStepIsSet(&testCfg.cfg, webuiStep) {
+	for _, testCfg := range v.testCfgs {
+		if validationStepIsSet(testCfg.cfg, webuiStep) {
 			err := validateWebUIForTest(codeBaseDir, testCfg, port)
 			if err != nil {
 				return fmt.Errorf("validateWebUIForTest() failed: %s", err)
@@ -581,10 +591,100 @@ func validateWebUI(codeBaseDir string, collectiveName string, profilerResults ma
 	return nil
 }
 
-// validateProfiler runs the profiler against examples and compare the resuls to the results output.
+// profiler runs the profiler against examples and compare the resuls to the results output.
 // If keepResults is set to true, the results are *not* removed after execution. They can then be used
 // later on to validate postmortem analysis.
-func validateProfiler(keepResults bool, fullValidation bool) (map[string]*testCfg, error) {
+func (v *validationCfg) profiler(keepResults bool, fullValidation bool) error {
+	_, filename, _, _ := runtime.Caller(0)
+	codeBaseDir := filepath.Join(filepath.Dir(filename), "..", "..", "..")
+
+	// Find MPI
+	mpiBin, err := exec.LookPath("mpirun")
+	if err != nil {
+		return err
+	}
+
+	// Find make
+	makeBin, err := exec.LookPath("make")
+	if err != nil {
+		return err
+	}
+
+	// Compile both the profiler libraries and the example
+	log.Println("Building libraries and tests...")
+	cmd := exec.Command(makeBin, "clean", "all")
+	cmd.Dir = filepath.Join(codeBaseDir, "src", "alltoallv")
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	cmd = exec.Command(makeBin, "clean", "all")
+	cmd.Dir = filepath.Join(codeBaseDir, "examples")
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	for testName, tt := range v.testCfgs {
+		// Create a temporary directory where to store the results
+		tempDir, err := ioutil.TempDir("", "")
+		if err != nil {
+			return err
+		}
+		v.testCfgs[testName].tempDir = tempDir
+
+		// Run the profiler
+		// todo: use https://github.com/gvallee/go_hpc_jobmgr so we can easilty validate on local machine and clusters
+		if validationStepIsSet(tt.cfg, traceGenerationStep) {
+			var stdout, stderr bytes.Buffer
+			for _, lib := range v.sharedLibraries {
+				pathToLib := filepath.Join(codeBaseDir, "src", tt.cfg.collective, lib)
+				fmt.Printf("Running MPI application (%s) and gathering profiles with %s...\n", testName, pathToLib)
+				cmd = exec.Command(mpiBin, "-np", strconv.Itoa(tt.cfg.np), "--oversubscribe", filepath.Join(codeBaseDir, "examples", testName))
+				cmd.Env = append(os.Environ(),
+					"LD_PRELOAD="+pathToLib,
+					"A2A_PROFILING_OUTPUT_DIR="+tempDir)
+				cmd.Dir = tempDir
+				cmd.Stdout = &stdout
+				cmd.Stderr = &stderr
+				err = cmd.Run()
+				if err != nil {
+					return fmt.Errorf("mpirun failed.\n\tstdout: %s\n\tstderr: %s", stdout.String(), stderr.String())
+				}
+			}
+
+			// Check the results
+			err = checkOutput(codeBaseDir, tempDir, tt.cfg)
+			if err != nil {
+				return err
+			}
+
+			// We clean up *only* when tests are successful and
+			// if results do not need to be kept
+			if !keepResults {
+				os.RemoveAll(tempDir)
+			}
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	verbose := flag.Bool("v", false, "Enable verbose mode")
+	counts := flag.Bool("counts", false, "Validate the count data generated during the validation run of the profiler with an MPI application. Requires the following additional options: -dir, -job, -id.")
+	profilerValidation := flag.Bool("profiler", false, "Perform a validation of the profiler itself running various tests. Requires MPI. Does not require any additional option.")
+	postmortemValidation := flag.Bool("postmortem", false, "Perform a validation of the postmortem analysis tools.")
+	full := flag.Bool("full", true, "Run the full validation. WARNING! This may generate a huge amount of files and create file system issues!")
+	dir := flag.String("dir", "", "Where all the data is")
+	id := flag.Int("id", 0, "Identifier of the experiment, e.g., X from <pidX> in the profile file name")
+	jobid := flag.Int("jobid", 0, "Job ID associated to the count files")
+	help := flag.Bool("h", false, "Help message")
+	webui := flag.Bool("webui", false, "Validate the WebUI")
+
+	flag.Parse()
+
 	defaultListGraphs := fmt.Sprintf("0-%d", profiler.DefaultNumGeneratedGraphs)
 	bigListGraphs := "0-999"
 	sharedLibraries := []string{sharedLibCounts, sharedLibBacktrace, sharedLibLocation, sharedLibLateArrival, sharedLibA2ATime,
@@ -627,6 +727,7 @@ func validateProfiler(keepResults bool, fullValidation bool) (map[string]*testCf
 			expectedBacktraceFiles:   []string{"alltoall_backtrace_rank0_trace0.md"}, // TODO What about an entry for "alltoall_comm_data_rank0.md", "counts.rank0_call0.md" and "counts.rank0_call0.md"???
 			//profilerStepsToExecute:         profiler.AllSteps,	//??? What is this
 		},
+		/* This test does not pass validation yet
 		{
 			collective:                     "alltoall",
 			requestedValidationStepsToRun:  []int{traceGenerationStep},
@@ -644,6 +745,7 @@ func validateProfiler(keepResults bool, fullValidation bool) (map[string]*testCf
 			expectedLateArrivalFiles: []string{"alltoall_late_arrival_times.rank0_comm0_job0.md", "alltoall_late_arrival_times.rank1_comm0_job0.md"},
 			expectedBacktraceFiles:   []string{"alltoall_backtrace_rank0_trace0.md", "alltoall_backtrace_rank1_trace0.md"},
 		},
+		*/
 		{
 			collective:                     "alltoall",
 			requestedValidationStepsToRun:  []int{traceGenerationStep},
@@ -684,7 +786,6 @@ func validateProfiler(keepResults bool, fullValidation bool) (map[string]*testCf
 			expectedHostHeatMapFiles: []string{"alltoallv_hosts-heat-map.rank0-recv.md", "alltoallv_hosts-heat-map.rank0-send.md"},
 			listGraphsToGenerate:     []string{defaultListGraphs},
 		},
-
 		{
 			collective:                     "alltoallv",
 			requestedValidationStepsToRun:  []int{allValidationSteps},
@@ -756,7 +857,7 @@ func validateProfiler(keepResults bool, fullValidation bool) (map[string]*testCf
 		},
 	}
 
-	if fullValidation {
+	if *full {
 		extaTests := []Test{
 			{
 				collective:                     "alltoallv",
@@ -785,122 +886,6 @@ func validateProfiler(keepResults bool, fullValidation bool) (map[string]*testCf
 		validationTests = append(validationTests, extaTests...)
 	}
 
-	_, filename, _, _ := runtime.Caller(0)
-	codeBaseDir := filepath.Join(filepath.Dir(filename), "..", "..", "..")
-
-	// Find MPI
-	mpiBin, err := exec.LookPath("mpirun")
-	if err != nil {
-		return nil, err
-	}
-
-	// Find make
-	makeBin, err := exec.LookPath("make")
-	if err != nil {
-		return nil, err
-	}
-
-	// Compile both the profiler libraries and the example
-	log.Println("Building libraries and tests...")
-	cmd := exec.Command(makeBin, "clean", "all")
-	cmd.Dir = filepath.Join(codeBaseDir, "src", "alltoallv")
-	err = cmd.Run()
-	if err != nil {
-		return nil, err
-	}
-
-	cmd = exec.Command(makeBin, "clean", "all")
-	cmd.Dir = filepath.Join(codeBaseDir, "examples")
-	err = cmd.Run()
-	if err != nil {
-		return nil, err
-	}
-
-	// Create a map to store the data about all the directories where
-	// results are created when the results need to be kept
-	var results map[string]*testCfg
-	if keepResults {
-		results = make(map[string]*testCfg)
-	}
-
-	for _, tt := range validationTests {
-		// Create a temporary directory where to store the results
-		tempDir, err := ioutil.TempDir("", "")
-		if err != nil {
-			return nil, err
-		}
-
-		// this has been moved up to make sure changes are copied to cfg.cfg
-		updateValidationStepsDependencies(&tt)
-
-		if keepResults {
-			cfg := new(testCfg)
-			cfg.tempDir = tempDir
-			cfg.cfg = tt // this copies the values of tt to cfg.cfg, so any changes to tt made below will not be reflected.
-			results[tt.binary] = cfg
-		}
-
-		// updateValidationStepsDependencies(&tt) // moved up to before "if keepResults {"
-		printValidationStepsToRun(&tt.validationStepsToRun, "in validateProfiler after retrun from updateValidationStepsDependencies")
-
-		// Run the profiler
-		// todo: use https://github.com/gvallee/go_hpc_jobmgr so we can easilty validate on local machine and clusters
-		if validationStepIsSet(&tt, traceGenerationStep) {
-			var stdout, stderr bytes.Buffer
-			for _, lib := range sharedLibraries {
-				pathToLib := filepath.Join(codeBaseDir, "src", tt.collective, lib)
-				fmt.Printf("Running MPI application (%s) and gathering profiles with %s...\n", tt.binary, pathToLib)
-				cmd = exec.Command(mpiBin, "-np", strconv.Itoa(tt.np), "--oversubscribe", filepath.Join(codeBaseDir, "examples", tt.binary))
-				cmd.Env = append(os.Environ(),
-					"LD_PRELOAD="+pathToLib,
-					"A2A_PROFILING_OUTPUT_DIR="+tempDir)
-				cmd.Dir = tempDir
-				cmd.Stdout = &stdout
-				cmd.Stderr = &stderr
-				err = cmd.Run()
-				if err != nil {
-					return nil, fmt.Errorf("mpirun failed.\n\tstdout: %s\n\tstderr: %s", stdout.String(), stderr.String())
-				}
-			}
-
-			// Check the results
-			err = checkOutput(codeBaseDir, tempDir, tt)
-			if err != nil {
-				return nil, err
-			}
-
-			// We clean up *only* when tests are successful and
-			// if results do not need to be kept
-			if !keepResults {
-				os.RemoveAll(tempDir)
-			}
-		}
-	}
-
-	// Return the map describing the data resulting from the tests only
-	// when the results need to be kept to later on validate postmortem
-	// analysis
-	if keepResults {
-		return results, nil
-	}
-
-	return nil, nil
-}
-
-func main() {
-	verbose := flag.Bool("v", false, "Enable verbose mode")
-	counts := flag.Bool("counts", false, "Validate the count data generated during the validation run of the profiler with an MPI application. Requires the following additional options: -dir, -job, -id.")
-	profiler := flag.Bool("profiler", false, "Perform a validation of the profiler itself running various tests. Requires MPI. Does not require any additional option.")
-	postmortem := flag.Bool("postmortem", false, "Perform a validation of the postmortem analysis tools.")
-	full := flag.Bool("full", true, "Run the full validation. WARNING! This may generate a huge amount of files and create file system issues!")
-	dir := flag.String("dir", "", "Where all the data is")
-	id := flag.Int("id", 0, "Identifier of the experiment, e.g., X from <pidX> in the profile file name")
-	jobid := flag.Int("jobid", 0, "Job ID associated to the count files")
-	help := flag.Bool("h", false, "Help message")
-	webui := flag.Bool("webui", false, "Validate the WebUI")
-
-	flag.Parse()
-
 	cmdName := filepath.Base(os.Args[0])
 	if *help {
 		fmt.Printf("%s validates various aspects of this infrastructure", cmdName)
@@ -918,7 +903,7 @@ func main() {
 		log.SetOutput(ioutil.Discard)
 	}
 
-	if !*counts && !*profiler && !*postmortem && !*webui {
+	if !*counts && !*profilerValidation && !*postmortemValidation && !*webui {
 		fmt.Println("No valid option selected, run '-h' for more details")
 		os.Exit(1)
 	}
@@ -929,32 +914,47 @@ func main() {
 	collectiveName := "alltoallv" // hardcoded for now, detection coming soon
 
 	if *webui {
-		*postmortem = true
+		*postmortemValidation = true
 	}
 
-	if *profiler && !*postmortem {
-		_, err := validateProfiler(false, *full)
+	// Create a map to store the data about all the directories where
+	// results are created when the results need to be kept
+	validation := new(validationCfg)
+	validation.tests = validationTests
+	validation.sharedLibraries = sharedLibraries
+	validation.testCfgs = make(map[string]*testCfg)
+
+	for idx, tt := range validationTests {
+		cfg := new(testCfg)
+		cfg.cfg = &validationTests[idx]
+		validation.testCfgs[tt.binary] = cfg
+	}
+
+	validation.updateValidationStepsDependencies()
+
+	if *profilerValidation && !*postmortemValidation {
+		err := validation.profiler(false, *full)
 		if err != nil {
 			fmt.Printf("Validation of the infrastructure failed: %s\n", err)
 			os.Exit(1)
 		}
 	}
 
-	if *postmortem {
-		profilerValidationResults, err := validateProfiler(true, *full)
-		if err != nil || profilerValidationResults == nil {
+	if *postmortemValidation {
+		err := validation.profiler(true, *full)
+		if err != nil {
 			fmt.Printf("Validation of the infrastructure failed: %s\n", err)
 			os.Exit(1)
 		}
 
-		err = validatePostmortemAnalysisTools(codeBaseDir, collectiveName, profilerValidationResults)
+		err = validation.postmortemAnalysisTools(codeBaseDir, collectiveName)
 		if err != nil {
 			fmt.Printf("Validation of the postmortem analysis tools failed: %s\n", err)
 			os.Exit(1)
 		}
 
 		if *webui {
-			err := validateWebUI(codeBaseDir, collectiveName, profilerValidationResults)
+			err := validation.webUI(codeBaseDir, collectiveName)
 			if err != nil {
 				fmt.Printf("Validation of the WebUI failed: %s", err)
 				os.Exit(1)
@@ -962,7 +962,7 @@ func main() {
 		}
 
 		// If successful, we can then delete all the directory that were created
-		for _, cfg := range profilerValidationResults {
+		for _, cfg := range validation.testCfgs {
 			os.RemoveAll(cfg.tempDir)
 		}
 

--- a/tools/cmd/validate/validate.go
+++ b/tools/cmd/validate/validate.go
@@ -830,14 +830,17 @@ func validateProfiler(keepResults bool, fullValidation bool) (map[string]*testCf
 			return nil, err
 		}
 
+		// this has been moved up to make sure changes are copied to cfg.cfg
+		updateValidationStepsDependencies(&tt)
+
 		if keepResults {
 			cfg := new(testCfg)
 			cfg.tempDir = tempDir
-			cfg.cfg = tt
+			cfg.cfg = tt // this copies the values of tt to cfg.cfg, so any changes to tt made below will not be reflected.
 			results[tt.binary] = cfg
 		}
 
-		updateValidationStepsDependencies(&tt)
+		// updateValidationStepsDependencies(&tt) // moved up to before "if keepResults {"
 		printValidationStepsToRun(&tt.validationStepsToRun, "in validateProfiler after retrun from updateValidationStepsDependencies")
 
 		// Run the profiler

--- a/tools/cmd/validate/validate.go
+++ b/tools/cmd/validate/validate.go
@@ -110,8 +110,13 @@ type testCfg struct {
 	cfg     Test
 }
 
+func printValidationStepsToRun(validationStepsToRun *map[int]bool, heading string) {
+	fmt.Printf("validationStepToRun value (%s): %v \n", heading, validationStepsToRun)
+}
+
 func updateValidationStepsDependencies(tt *Test) {
 	tt.validationStepsToRun = make(map[int]bool)
+	printValidationStepsToRun(&tt.validationStepsToRun, "on map init in updateValidationStepsDependencies")
 
 	for _, step := range tt.requestedValidationStepsToRun {
 		if step == allValidationSteps {
@@ -130,9 +135,11 @@ func updateValidationStepsDependencies(tt *Test) {
 
 		tt.validationStepsToRun[step] = true
 	}
+	printValidationStepsToRun(&tt.validationStepsToRun, "after setting in updateValidationStepsDependencies")
 }
 
 func validationStepIsSet(tt *Test, requestedStep int) bool {
+	printValidationStepsToRun(&tt.validationStepsToRun, "in validationStepIsSet")
 	return tt.validationStepsToRun[requestedStep]
 }
 
@@ -831,6 +838,7 @@ func validateProfiler(keepResults bool, fullValidation bool) (map[string]*testCf
 		}
 
 		updateValidationStepsDependencies(&tt)
+		printValidationStepsToRun(&tt.validationStepsToRun, "in validateProfiler after retrun from updateValidationStepsDependencies")
 
 		// Run the profiler
 		// todo: use https://github.com/gvallee/go_hpc_jobmgr so we can easilty validate on local machine and clusters

--- a/tools/cmd/validate/validate.go
+++ b/tools/cmd/validate/validate.go
@@ -111,7 +111,7 @@ type testCfg struct {
 }
 
 func printValidationStepsToRun(validationStepsToRun *map[int]bool, heading string) {
-	fmt.Printf("validationStepToRun value (%s): %v \n", heading, validationStepsToRun)
+	fmt.Printf("validationStepsToRun value (%s): %v \n", heading, validationStepsToRun)
 }
 
 func updateValidationStepsDependencies(tt *Test) {


### PR DESCRIPTION
A bug was noted for branch  alltoallv_validation_suggestion that for validation functions validatePostmortemAnalysisTools and validateWebUI the list of validation steps to run is empty. 

The bug seems to be that a *copy* of the test struct is saved in validateProfiler but this copy was made before the validation steps were added to the test struct by updateValidationStepsDependencies, which has therefore been moved up to before where the copy is saved. 

The result is that the validation does proceed further, providing further log on stdout (I guess from validatePostmortemAnalysisTools). For validateWebUI stdout shows the trace added in this branch to show teh valuesof validationStepsToRun but nothing else.

Marked WIP to avoid merging anywhere important. This branch is also not directly based on alltoallv_validation_suggestion but my later branch making use of that, so in total this branch contains lots of things apart from the bug fix.